### PR TITLE
Highlight vegan badges with outlined styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,8 @@
     .food-name{ font-weight:500; text-transform:uppercase; letter-spacing:.02em }
     .food-price{ font-variant-numeric:tabular-nums }
     .badges{ display:flex; gap:6px; margin-top:6px }
-    .badge{ font-size:12px; padding:4px 8px; border-radius:999px; border:1px solid rgba(27,38,33,.15) }
+    .badge{ display:inline-flex; align-items:center; gap:6px; font-size:12px; font-weight:500; padding:4px 10px; border-radius:999px; border:1px solid rgba(27,38,33,.15); color:var(--muted); background-color:rgba(27,38,33,.02) }
+    .badge-vegan{ border-color:#7fb569; color:#46623d; background-color:rgba(127,181,105,.12) }
     footer{ padding:34px 0 60px }
     .ig{ display:inline-flex; padding:8px; border-radius:999px; border:1px solid rgba(27,38,33,.18) }
     .ig svg{ width:28px; height:28px; display:block }
@@ -154,90 +155,89 @@
       <h2>Еда (здоровые перекусы)</h2>
       <div class="food-grid">
         <article class="food-item" data-tags="vegan">
-          <div class="food-head"><div class="food-name">Morning Glow</div><div class="food-price">2000</div></div>
+          <div class="food-head"><div class="food-name">Morning Glow</div><div class="food-price">2&nbsp;000&nbsp;тг</div></div>
           <div class="meta">— Льняная каша (Лен, миндальное молоко)</div>
-          <div class="meta">351 ккал • Белки 11,7 • Жиры 28,1 • Углеводы 12,3</div>
-          <div class="badges"><span class="badge">🌱 Vegan</span></div>
-        </article>
-        <article class="food-item" data-tags="vegan">
-          <div class="food-head"><div class="food-name">Golden Porridge</div><div class="food-price">1500</div></div>
-          <div class="meta">— Каша пшённая (Пшено, миндальное молоко, масло гхи, джем)</div>
-          <div class="meta">251 ккал • Белки 5,5 • Жиры 7,9 • Углеводы 41,3</div>
-          <div class="badges"><span class="badge">🌱 Vegan</span></div>
+          <div class="meta">200 г • 351 ккал • Белки 11,7 • Жиры 28,1 • Углеводы 12,3</div>
+          <div class="badges"><span class="badge badge-vegan">🌱 Vegan</span></div>
         </article>
         <article class="food-item">
-          <div class="food-head"><div class="food-name">Double Egg</div><div class="food-price">1000</div></div>
+          <div class="food-head"><div class="food-name">Golden Porridge</div><div class="food-price">1&nbsp;500&nbsp;тг</div></div>
+          <div class="meta">— Каша пшенная (Пшено, миндальное молоко, масло гхи, джем)</div>
+          <div class="meta">280 г • 251 ккал • Белки 5,5 • Жиры 7,9 • Углеводы 41,3</div>
+        </article>
+        <article class="food-item">
+          <div class="food-head"><div class="food-name">Double Egg</div><div class="food-price">1&nbsp;000&nbsp;тг</div></div>
           <div class="meta">— Белковый перекус (2 отварных куриных яйца с зеленью)</div>
-          <div class="meta">159 ккал • Белки 16 • Жиры 11,1 • Углеводы 1,5</div>
+          <div class="meta">135 г • 159 ккал • Белки 16 • Жиры 11,1 • Углеводы 1,5</div>
         </article>
         <article class="food-item">
-          <div class="food-head"><div class="food-name">Green Power Bowl</div><div class="food-price">3000</div></div>
+          <div class="food-head"><div class="food-name">Green Power Bowl</div><div class="food-price">3&nbsp;000&nbsp;тг</div></div>
           <div class="meta">— Боул с брокколи (Микс салат, скрембл, брокколи, черри, оливки, лимонный соус)</div>
-          <div class="meta">295 ккал • Белки 22,8 • Жиры 20,5 • Углеводы 1,5</div>
+          <div class="meta">405 г • 295 ккал • Белки 22,8 • Жиры 20,5 • Углеводы 1,5</div>
         </article>
         <article class="food-item">
-          <div class="food-head"><div class="food-name">Corn &amp; Cheese Club</div><div class="food-price">3000</div></div>
+          <div class="food-head"><div class="food-name">Corn &amp; Cheese Club</div><div class="food-price">3&nbsp;000&nbsp;тг</div></div>
           <div class="meta">— Клаб-сэндвич с кукурузой (Тост хлеб, кукурузная паста, сыр моцарелла, куриное филе)</div>
-          <div class="meta">523 ккал • Белки 38,8 • Жиры 22,5 • Углеводы 41,3</div>
+          <div class="meta">220 г • 523 ккал • Белки 38,8 • Жиры 22,5 • Углеводы 41,3</div>
         </article>
         <article class="food-item">
-          <div class="food-head"><div class="food-name">Garden Club</div><div class="food-price">3000</div></div>
+          <div class="food-head"><div class="food-name">Garden Club</div><div class="food-price">3&nbsp;000&nbsp;тг</div></div>
           <div class="meta">— Клаб-сэндвич с огурцом (Тост хлеб, микс салат, огурцы, куриное филе, сыр моцарелла)</div>
-          <div class="meta">396 ккал • Белки 34,1 • Жиры 14,6 • Углеводы 32,2</div>
+          <div class="meta">220 г • 396 ккал • Белки 34,1 • Жиры 14,6 • Углеводы 32,2</div>
         </article>
         <article class="food-item">
-          <div class="food-head"><div class="food-name">Fresh Wrap</div><div class="food-price">3000</div></div>
+          <div class="food-head"><div class="food-name">Fresh Wrap</div><div class="food-price">3&nbsp;000&nbsp;тг</div></div>
           <div class="meta">— Врап с курицей (Курица, красная капуста, зелень, лаваш)</div>
-          <div class="meta">353 ккал • Белки 30 • Жиры 6 • Углеводы 46</div>
+          <div class="meta">220 г • 353 ккал • Белки 30 • Жиры 6 • Углеводы 46</div>
         </article>
         <article class="food-item">
-          <div class="food-head"><div class="food-name">Matcha Bliss</div><div class="food-price">3000</div></div>
+          <div class="food-head"><div class="food-name">Matcha Bliss</div><div class="food-price">3&nbsp;000&nbsp;тг</div></div>
           <div class="meta">— Гранола с зелёной матчей (Греческий йогурт, зелёная матча, зелёное яблоко, гранола)</div>
-          <div class="meta">229 ккал • Белки 13,4 • Жиры 7,2 • Углеводы 30,6</div>
+          <div class="meta">200 г • 229 ккал • Белки 13,4 • Жиры 7,2 • Углеводы 30,6</div>
         </article>
         <article class="food-item">
-          <div class="food-head"><div class="food-name">Blue Bliss</div><div class="food-price">3000</div></div>
+          <div class="food-head"><div class="food-name">Blue Bliss</div><div class="food-price">3&nbsp;000&nbsp;тг</div></div>
           <div class="meta">— Чиа-пудинг (Чиа, голубая матча, греческий йогурт, кокосовое молоко)</div>
-          <div class="meta">280 ккал • Белки 15 • Жиры 18,7 • Углеводы 16</div>
+          <div class="meta">200 г • 280 ккал • Белки 15 • Жиры 18,7 • Углеводы 16</div>
         </article>
         <article class="food-item">
-          <div class="food-head"><div class="food-name">Coffella Waffle</div><div class="food-price">2000</div></div>
+          <div class="food-head"><div class="food-name">Coffella Waffle</div><div class="food-price">2&nbsp;000&nbsp;тг</div></div>
           <div class="meta">— Творожная вафля (Творог, яйцо, безглютеновая мука)</div>
-          <div class="meta">186 ккал • Белки 21 • Жиры 4,5 • Углеводы 16</div>
+          <div class="meta">100 г • 186 ккал • Белки 21 • Жиры 4,5 • Углеводы 16</div>
         </article>
         <article class="food-item">
-          <div class="food-head"><div class="food-name">Protein Snack</div><div class="food-price">1200</div></div>
+          <div class="food-head"><div class="food-name">Protein Snack</div><div class="food-price">1&nbsp;200&nbsp;тг</div></div>
           <div class="meta">— Протеиновые печеньки (Орехи, финики, протеин)</div>
-          <div class="meta">477 ккал • Белки 24,1 • Жиры 31,5 • Углеводы 37,6</div>
+          <div class="meta">120 г • 477 ккал • Белки 24,1 • Жиры 31,5 • Углеводы 37,6</div>
         </article>
         <article class="food-item" data-tags="vegan">
-          <div class="food-head"><div class="food-name">Energy Bar</div><div class="food-price">3000</div></div>
-          <div class="meta">— Ореховый батончик (Орехи, финики, масло какао, какао)</div>
-          <div class="meta">354 ккал • Белки 8 • Жиры 22,6 • Углеводы 37,6</div>
-          <div class="badges"><span class="badge">🌱 Vegan</span></div>
+          <div class="food-head"><div class="food-name">Energy Bar</div><div class="food-price">3&nbsp;000&nbsp;тг</div></div>
+          <div class="meta">— Ореховый батончик (Орехи, финики, какао масло, какао)</div>
+          <div class="meta">80 г • 354 ккал • Белки 8 • Жиры 22,6 • Углеводы 37,6</div>
+          <div class="badges"><span class="badge badge-vegan">🌱 Vegan</span></div>
         </article>
         <article class="food-item">
-          <div class="food-head"><div class="food-name">Фирменный панини с кониной</div><div class="food-price">3000</div></div>
+          <div class="food-head"><div class="food-name">Фирменный панини с кониной</div><div class="food-price">3&nbsp;000&nbsp;тг</div></div>
           <div class="meta">— Панини, творожный сыр, корнишоны, конина вяленая, горчица, терияки, фирменный соус</div>
-          <div class="meta">843 ккал • Белки 35,5 • Жиры 39,1 • Углеводы 50,6</div>
+          <div class="meta">275 г • 843 ккал • Белки 35,5 • Жиры 39,1 • Углеводы 50,6</div>
         </article>
         <article class="food-item">
-          <div class="food-head"><div class="food-name">Фирменный панини с индейкой</div><div class="food-price">3000</div></div>
+          <div class="food-head"><div class="food-name">Фирменный панини с индейкой</div><div class="food-price">3&nbsp;000&nbsp;тг</div></div>
           <div class="meta">— Панини, творожный сыр, песто, вяленые помидоры, оливки, индейка, фирменный соус</div>
-          <div class="meta">728 ккал • Белки 29,3 • Жиры 43,3 • Углеводы 54,3</div>
+          <div class="meta">275 г • 728 ккал • Белки 29,3 • Жиры 43,3 • Углеводы 54,3</div>
         </article>
         <article class="food-item">
-          <div class="food-head"><div class="food-name">Джем без сахара</div><div class="food-price">500</div></div>
-          <div class="meta">12 ккал</div>
+          <div class="food-head"><div class="food-name">Джем без сахара</div><div class="food-price">500&nbsp;тг</div></div>
+          <div class="meta">25 г • 12 ккал</div>
         </article>
         <article class="food-item">
-          <div class="food-head"><div class="food-name">Творожный соус</div><div class="food-price">500</div></div>
-          <div class="meta">51 ккал • Белки 0,9 • Жиры 5,1 • Углеводы 0,6</div>
+          <div class="food-head"><div class="food-name">Творожный соус</div><div class="food-price">500&nbsp;тг</div></div>
+          <div class="meta">25 г • 51 ккал • Белки 0,9 • Жиры 5,1 • Углеводы 0,6</div>
         </article>
         <article class="food-item">
-          <div class="food-head"><div class="food-name">Veggy Bun</div><div class="food-price">600</div></div>
+          <div class="food-head"><div class="food-name">Veggy Bun</div><div class="food-price">600&nbsp;тг</div></div>
           <div class="meta">— Чечевичная булочка (Яблоко, чечевица, псиллиум, закваска, кориандр, соль)</div>
-          <div class="meta">110 ккал • Белки 6 • Жиры 1,5 • Углеводы 17</div>
+          <div class="meta">50 г • 110 ккал • Белки 6 • Жиры 1,5 • Углеводы 17</div>
         </article>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- format food item pricing with non-breaking spaces and include currency labels
- add serving weight to nutritional lines and align ingredient descriptions with the latest data
- drop the vegan badge from Golden Porridge to reflect the presence of ghee
- outline vegan badges to make the category stand out visually

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68cbdfc62e1c8321b06d6665a5644034